### PR TITLE
Add fallback attribute for disciminated union.

### DIFF
--- a/src/Vertigo.Json/ApiTypes.fs
+++ b/src/Vertigo.Json/ApiTypes.fs
@@ -22,6 +22,7 @@ type JsonProperty (propertyName: string) =
     member val public EnumValue: EnumValue = EnumValue.String with get, set
     member val public DefaultValue: obj = null with get, set
     member val public DateTimeFormat: string = null with get, set
+    member val public IsFallback : bool = false with get, set
     new () = JsonProperty(null)
 with
     static member Default = JsonProperty()

--- a/tests/Vertigo.Json.Tests/Union.fs
+++ b/tests/Vertigo.Json.Tests/Union.fs
@@ -8,8 +8,16 @@ module Union =
     | StringCase of string
     | MultifieldCase of string*int
 
+    type TheUnionWithFallback =
+    | NumCase of int
+    | [<JsonProperty(IsFallback = true)>] Fallback of obj
+
     type TheRecord = {
         amember: TheUnion
+    }
+
+    type TheRecordWithFallback = {
+        amember : TheUnionWithFallback
     }
 
     [<Test>]
@@ -25,6 +33,14 @@ module Union =
         let json = Json.serialize(value)
         let actual = Json.deserialize<TheRecord>(json)
         Assert.AreEqual(value, actual)
+
+    [<Test>]
+    let ``Union deserialization fallback`` () =
+        let value = """{"amember": {"NonExistCase": "hello"}}"""
+        let deserialized = Json.deserialize<TheRecordWithFallback> value
+        match deserialized.amember with
+        | Fallback x -> Assert.AreEqual(x.ToString(), "hello")
+        | _ -> failwith "Not correctly matching fallback"
 
     [<Test>]
     let ``Union multifield serialization`` () =

--- a/tests/Vertigo.Json.Tests/Union.fs
+++ b/tests/Vertigo.Json.Tests/Union.fs
@@ -18,6 +18,7 @@ module Union =
 
     type TheRecordWithFallback = {
         amember : TheUnionWithFallback
+        bmember : TheUnionWithFallback
     }
 
     [<Test>]
@@ -36,11 +37,15 @@ module Union =
 
     [<Test>]
     let ``Union deserialization fallback`` () =
-        let value = """{"amember": {"NonExistCase": "hello"}}"""
+        let value = """{"amember": {"NonExistCase": "hello"}, "bmember": {"NumCase": 22}}"""
         let deserialized = Json.deserialize<TheRecordWithFallback> value
         match deserialized.amember with
         | Fallback x -> Assert.AreEqual(x.ToString(), "hello")
         | _ -> failwith "Not correctly matching fallback"
+
+        match deserialized.bmember with
+        | NumCase x -> Assert.AreEqual(x, 22)
+        | _ -> failwith "Case not matching"
 
     [<Test>]
     let ``Union multifield serialization`` () =


### PR DESCRIPTION
Occasionally, we were finding that there would be DU cases that we didn't
anticipate.  The goal of this PR is to allow an optional fallback to use
something generic when needed.