### PR TITLE
Add a more descriptive error if we are unable to cast to a string.

### DIFF
--- a/src/Vertigo.Json/Reflection.Json.fs
+++ b/src/Vertigo.Json/Reflection.Json.fs
@@ -269,7 +269,7 @@ module internal Internals =
                     |> Seq.map (fun o ->
                         let key = 
                             try FSharpValue.KvpKey o :?> string 
-                            with | ex -> failwith "Issue casting JSON key to string. The JSON Specification currently only allows string-keys."
+                            with | ex -> failwith (sprintf "Issue casting JSON key to string. The JSON Specification currently only allows string-keys.\n %s" <| ex.ToString())
                         let value = FSharpValue.KvpValue o
                         let jtype = if isNull value then (Some ()).GetType() else value.GetType()
                         let jvalue = Serialize.Option config jtype value JsonProperty.Default

--- a/src/Vertigo.Json/Reflection.Json.fs
+++ b/src/Vertigo.Json/Reflection.Json.fs
@@ -267,7 +267,9 @@ module internal Internals =
                 let properties =
                     kvps.Cast<Object>()
                     |> Seq.map (fun o ->
-                        let key = FSharpValue.KvpKey o :?> string
+                        let key = 
+                            try FSharpValue.KvpKey o :?> string 
+                            with | ex -> failwith "Issue casting JSON key to string. The JSON Specification currently only allows string-keys."
                         let value = FSharpValue.KvpValue o
                         let jtype = if isNull value then (Some ()).GetType() else value.GetType()
                         let jvalue = Serialize.Option config jtype value JsonProperty.Default


### PR DESCRIPTION
Added a more descriptive error, since we noticed that it threw a slightly confusing exception when trying to pass in keys of other types. 